### PR TITLE
[FIX] RTL margins and float directions

### DIFF
--- a/scss/utilities/_float.scss
+++ b/scss/utilities/_float.scss
@@ -2,8 +2,8 @@
   @include media-breakpoint-up($breakpoint) {
     $infix: breakpoint-infix($breakpoint, $grid-breakpoints);
 
-    .float#{$infix}-left  { @include float-left; }
-    .float#{$infix}-right { @include float-right; }
+    .float#{$infix}-right  { @include float-left; }
+    .float#{$infix}-left { @include float-right; }
     .float#{$infix}-none  { @include float-none; }
   }
 }

--- a/scss/utilities/_spacing.scss
+++ b/scss/utilities/_spacing.scss
@@ -15,7 +15,7 @@
         }
         .#{$abbrev}r#{$infix}-#{$size},
         .#{$abbrev}x#{$infix}-#{$size} {
-          #{$prop}-right: $length !important;
+          #{$prop}-left: $length !important;
         }
         .#{$abbrev}b#{$infix}-#{$size},
         .#{$abbrev}y#{$infix}-#{$size} {
@@ -23,7 +23,7 @@
         }
         .#{$abbrev}l#{$infix}-#{$size},
         .#{$abbrev}x#{$infix}-#{$size} {
-          #{$prop}-left: $length !important;
+          #{$prop}-right: $length !important;
         }
       }
     }
@@ -38,7 +38,7 @@
         }
         .mr#{$infix}-n#{$size},
         .mx#{$infix}-n#{$size} {
-          margin-right: -$length !important;
+          margin-left: -$length !important;
         }
         .mb#{$infix}-n#{$size},
         .my#{$infix}-n#{$size} {
@@ -46,7 +46,7 @@
         }
         .ml#{$infix}-n#{$size},
         .mx#{$infix}-n#{$size} {
-          margin-left: -$length !important;
+          margin-right: -$length !important;
         }
       }
     }
@@ -59,7 +59,7 @@
     }
     .mr#{$infix}-auto,
     .mx#{$infix}-auto {
-      margin-right: auto !important;
+      margin-left: auto !important;
     }
     .mb#{$infix}-auto,
     .my#{$infix}-auto {
@@ -67,7 +67,7 @@
     }
     .ml#{$infix}-auto,
     .mx#{$infix}-auto {
-      margin-left: auto !important;
+      margin-right: auto !important;
     }
   }
 }


### PR DESCRIPTION
Hi,

1. This fixes up `float-right` or `float-left` when changing from `ltr` to `rtl`.
2. Also fixed `ml-auto` and `mr-auto`.